### PR TITLE
Add support for macOS

### DIFF
--- a/extender.sh
+++ b/extender.sh
@@ -12,6 +12,11 @@ ok="Your add-on has been submitted for review."
 # chop off everything after "$ok" (it contains distracting stacktrace)
 web-ext "$@" | sed "/$ok/q" | tee "$tmp"
 error=${PIPESTATUS[0]}
+# pass other errors intact
+if [ $error != 1 ] ; then
+	exit $error
+fi
+# defensive if add-on was submitted
 if ! grep -q "$ok" "$tmp" && [ $error = 1 ] ; then
 	exit $error
 fi

--- a/extender.sh
+++ b/extender.sh
@@ -9,7 +9,8 @@ cd - > /dev/null || exit
 set -- "sign" "${@:1}" # https://stackoverflow.com/a/4827707/288906
 tmp="$(mktemp)"
 ok="Your add-on has been submitted for review."
-web-ext "$@" | sed -n "s/\($ok\).*$/\0/;1,/$ok/p" | tee "$tmp"
+# chop off everything after "$ok" (it contains distracting stacktrace)
+web-ext "$@" | sed "/$ok/q" | tee "$tmp"
 error=${PIPESTATUS[0]}
 if ! grep -q "$ok" "$tmp" && [ $error = 1 ] ; then
 	exit $error


### PR DESCRIPTION
Got a macbook and ran into a similar issue https://github.com/fregante/web-ext-submit/issues/1
I think the problem is that sed on macos doesn't support multiple commands (separated with `;`).
I simplified it and I believe it achieves the same while being portable (I tested it by publishing my addon).
Acording to [docs](https://www.gnu.org/software/sed/manual/sed.html#index-GNU-extensions_002c-returning-an-exit-code), `q` operator does "Exit sed without processing any more commands or input.", which I believe is the intent of the sed comamd there? 

I also made did the change to make the script a bit less defensive -- not sure if you think it makes sense, so feel free to drop that commit if you don't :) 
